### PR TITLE
Use environment variables to override any setting in runtime.properties and common.runtime.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Druid is an open-source analytics data store designed for business intelligence 
 How to use?
 ===========
 
-Druid being a complex system, the best way to get up and running with a cluster is to use the docker-compose file provided. 
+Druid being a complex system, the best way to get up and running with a cluster is to use the docker-compose file provided.
 
 Clone our public repository:
 
@@ -61,6 +61,10 @@ Available environment options:
 - `DRUID_NEWSIZE` '-'
 - `DRUID_MAXNEWSIZE` '-'
 - `DRUID_HOSTNAME` '-'
+
+You can override *any* setting in `common.runtime.properties` and `runtime.properties` by setting an environment variable that matches the property name, converted to uppercase and with `.` replaced by `_`.
+
+For example, if you want to override the setting `druid.metadata.storage.connector.user` and set it to `DBUSER`, set the environment variable `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER`.
 
 Authors
 =======

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,4 +35,11 @@ if [ "$DRUID_USE_CONTAINER_IP" != "-" ]; then
     sed -ri 's/druid.host=.*/druid.host='${ipaddress}'/g' /opt/druid/conf/druid/$1/runtime.properties
 fi
 
-java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@
+# catch all environment vars that start with DRUID_ and set them to override druid.
+druidVars=$(env | awk -F= '/^DRUID_/ {
+    gsub("_",".",$1)
+    print "-D"tolower($1)"="$2
+}')
+
+
+java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` ${druidVars} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@


### PR DESCRIPTION
For example, setting the environment variable `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER` would override `druid.metadata.storage.connector.user` and set it to `DBUSER`.

This follows the spring framework style for overriding application properties.